### PR TITLE
Fixing the regex

### DIFF
--- a/src/tinyModal.js
+++ b/src/tinyModal.js
@@ -111,7 +111,7 @@ var tinyModal = (function(){
 	function openModal(selector, onOpen){
 		if (selector.indexOf("#") > -1) {
 			popup = document.querySelector(selector);
-		} else if (selector.match(/[.jpg|.JPG|.png|.PNG|.gif|.GIF]/)) {
+		} else if (selector.match(/.*(\.(jpg|png|gif))$/i)) {
 			popup = document.createElement("aside");
 			popup.setAttribute("class","tinymodal-window tinymodal-new");
 			popup.innerHTML = "<div class=\"tinymodal-inner\"><img src=\"" + selector + "\" /></div>";


### PR DESCRIPTION
The new regex for image now looks for image file extensions at the end of the line only (so `test.png` will pass but `test.png.log` won't).
It is also case insensitive now so no need to multiple images strings.
Lastly, the leading dot is now correctly escaped.